### PR TITLE
Update script: Pull correct years, handle exception

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -3,14 +3,20 @@ name: AutoUpdate
 on: 
   schedule:
     - cron: "5 12 * * 6"
+  push:
+    branches:
+      - master
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-      with:
-        ref: master
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
@@ -21,6 +27,8 @@ jobs:
       run: python update.py
     - name: Commit changes 
       uses: EndBug/add-and-commit@v2.1.0 
+      # Commit only if this is not a PR
+      if: github.ref == 'master' 
       with: 
         author_name: GitHub Action
         author_email: action@github.com

--- a/update.py
+++ b/update.py
@@ -123,7 +123,7 @@ def years_to_recheck():
     e.g. [2018, 2019]
     """
     cur_year = date.today().year
-    return list(range(cur_year - YEARS_TO_GO_BACK + 1, cur_year))
+    return list(range(cur_year - YEARS_TO_GO_BACK + 1, cur_year + 1))
 
 
 def main():

--- a/update.py
+++ b/update.py
@@ -29,6 +29,14 @@ def get_case(term, docket):
     url = f"https://api.oyez.org/cases/{term}/{docket}"
     docket_data = get_http_json(url)
 
+    if not (
+        "oral_argument_audio" in docket_data and docket_data["oral_argument_audio"]
+    ):
+        # no oral arguments for this case yet
+        # fail so we will try again later
+        print(f"No oral arguments for docket {docket}")
+        return (docket_data, [])
+
     oral_argument_audio = docket_data["oral_argument_audio"]
     transcripts = []
     for link in oral_argument_audio:
@@ -70,6 +78,10 @@ def fetch_missing(cases):
         print(f"Trying: {term}/{docket}\t\t{count}/{total}")
         try:
             docket_data, transcripts = get_case(term, docket)
+            if not transcripts:
+                # No transcripts for this case yet
+                continue
+
             write_case(term, docket, docket_data, transcripts)
             succesful.add((term, docket))
         except Exception as exc:


### PR DESCRIPTION
This PR achieves three things:

- Handle cases with missing oral_arguments more cleanly
- Pulls data from the right years (current year was missing)
- Runs auto-update action more often so we can validate script changes quickly

Each of those changes are in a separate commit.