### PR TITLE
fix(workflows): get `auto-update` and `auto-publish` back up and running

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install dependencies

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.ref }} # explicit ref so that it can be pushed against by add-and-commit below
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
@@ -28,14 +30,13 @@ jobs:
     - name: Fetch and update cases
       run: python update.py
     - name: Commit changes 
-      uses: EndBug/add-and-commit@v2.1.0 
+      uses: EndBug/add-and-commit@v9.1.4
       # Commit only if this is not a PR
       if: github.ref == 'refs/heads/master'
       with: 
         author_name: GitHub Action
         author_email: action@github.com
         message: "Add new cases!"
-        path: "."
-        pattern: "*.json"
+        add: "*.json"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v5
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
These two workflows have broken down because their dependencies have stopped working well. Upgrading `actions/checkout`, `actions/setup-python`, and `EndBug/add-and-commit` gets them working again.

